### PR TITLE
Fix govulncheck action version

### DIFF
--- a/.github/workflows/govun.yaml
+++ b/.github/workflows/govun.yaml
@@ -7,4 +7,4 @@ jobs:
     steps:
       - uses: golang/govulncheck-action@v1
         with:
-          go-version-input: '1.18'
+          go-version-input: '1.22'


### PR DESCRIPTION
## Summary
- use Go 1.22 for the govulncheck workflow so that the dependency can install

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854ddf1e440832fa135b8bca2346da0