### PR TITLE
Update govulncheck workflow Go version

### DIFF
--- a/.github/workflows/govun.yaml
+++ b/.github/workflows/govun.yaml
@@ -7,4 +7,4 @@ jobs:
     steps:
       - uses: golang/govulncheck-action@v1
         with:
-          go-version-input: '1.18'
+          go-version-input: '1.22.x'


### PR DESCRIPTION
## Summary
- update `govun.yaml` to use Go 1.22.x to support current govulncheck

## Testing
- `go fmt ./...`
- `go vet ./...`
- `go build ./...`
- `go test ./...`

------
https://chatgpt.com/codex/tasks/task_e_6854dd10110c832f9a50590ffa5a95fb